### PR TITLE
Upload to maven central + PGP and Jar sign artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,14 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: gradle/wrapper-validation-action@v1
-      - run: ./gradlew checkVersion build publish --stacktrace
+      - run: ./gradlew checkVersion build signJar publish --stacktrace
         env:
           MAVEN_URL: ${{ secrets.MAVEN_URL }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_CENTRAL_URL: ${{ secrets.MAVEN_CENTRAL_URL }}
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_SERVER: ${{ secrets.SIGNING_SERVER }}
+          SIGNING_PGP_KEY: ${{ secrets.SIGNING_PGP_KEY }}
+          SIGNING_JAR_KEY: ${{ secrets.SIGNING_JAR_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -128,8 +128,8 @@ publishing {
 
 					developer {
 						id = "sfPlayer"
-						name = "sfPlayer"
-						email = "sfPlayer@fabricmc.net"
+						name = "Player"
+						email = "player@fabricmc.net"
 					}
 				}
 			}

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
 	id "java-library"
 	id "checkstyle"
 	id "maven-publish"
+	id "me.modmuss50.remotesign" version "0.1.0"
 	id "net.minecrell.licenser" version "0.4.1"
 }
 
@@ -13,8 +14,8 @@ group "net.fabricmc"
 archivesBaseName = "access-widener"
 
 def ENV = System.getenv()
-version = "1.0.0"
-logger.lifecycle("Building Accesswidener: " + version)
+version = "1.0.1"
+logger.lifecycle("Building AccessWidener: " + version)
 
 repositories {
 	mavenCentral()
@@ -22,6 +23,14 @@ repositories {
 	maven {
 		name = "Fabric"
 		url = "https://maven.fabricmc.net/"
+	}
+}
+
+tasks.withType(JavaCompile).configureEach {
+	it.options.encoding = "UTF-8"
+
+	if (JavaVersion.current().isJava9Compatible()) {
+		it.options.release = 8
 	}
 }
 
@@ -42,9 +51,8 @@ checkstyle {
 	toolVersion = "8.31"
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-	archiveClassifier = 'sources'
-	from sourceSets.main.allSource
+java {
+	withSourcesJar()
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -52,13 +60,79 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 	from javadoc.destinationDir
 }
 
+if (ENV.SIGNING_SERVER) {
+	remoteSign {
+		requestUrl ENV.SIGNING_SERVER
+		pgpAuthKey ENV.SIGNING_PGP_KEY
+		jarAuthKey ENV.SIGNING_JAR_KEY
+
+		sign (jar, javadocJar, sourcesJar)
+
+		afterEvaluate {
+			sign publishing.publications.mavenJava
+		}
+	}
+}
+
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
-			from components.java
+			if (ENV.SIGNING_SERVER) {
+				artifact(signJar) {
+					classifier null
+				}
 
-			artifact(sourcesJar)
-			artifact(javadocJar)
+				artifact(signJavadocJar) {
+					classifier "javadoc"
+				}
+
+				artifact(signSourcesJar) {
+					classifier "sources"
+				}
+			} else {
+				from components.java
+
+				artifact(sourcesJar)
+				artifact(javadocJar)
+			}
+
+			pom {
+				name = 'access-widener'
+				description = 'Access widener provides a way to loosen the access limits of classes in a data drive manner.'
+				url = 'https://github.com/FabricMC/access-widener'
+
+				scm {
+					connection = "scm:git:https://github.com/FabricMC/access-widener.git"
+					developerConnection = "scm:git:git@github.com:FabricMC/access-widener.git"
+					url = "https://github.com/FabricMC/access-widener"
+				}
+
+				issueManagement {
+					system = "GitHub"
+					url = "https://github.com/FabricMC/access-widener/issues"
+				}
+
+				licenses {
+					license {
+						name = 'The Apache License, Version 2.0'
+						url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					}
+				}
+
+				developers {
+					developer {
+						id = "modmuss50"
+						name = "modmuss50"
+						email = "modmuss50@fabricmc.net"
+					}
+
+					developer {
+						id = "sfPlayer"
+						name = "sfPlayer"
+						email = "sfPlayer@fabricmc.net"
+					}
+				}
+			}
 		}
 	}
 
@@ -71,6 +145,16 @@ publishing {
 				credentials {
 					username ENV.MAVEN_USERNAME
 					password ENV.MAVEN_PASSWORD
+				}
+			}
+		}
+
+		if (ENV.MAVEN_CENTRAL_URL) {
+			repositories.maven {
+				url ENV.MAVEN_CENTRAL_URL
+				credentials {
+					username ENV.MAVEN_CENTRAL_USERNAME
+					password ENV.MAVEN_CENTRAL_PASSWORD
 				}
 			}
 		}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,12 @@
+pluginManagement {
+	repositories {
+		maven {
+			name = 'Fabric'
+			url = 'https://maven.fabricmc.net/'
+		}
+		mavenCentral()
+		gradlePluginPortal()
+	}
+}
+
 rootProject.name = 'access-widener'


### PR DESCRIPTION
This is the first of a few planned libraries we are going to put onto maven central, the others that I can see that might be useful are as follows:

- tiny-mappings-parser
- tiny-remapper
- lorenz-tiny
- MappingPoet

One requirement for maven central is for the maven artifacts to be PGP signed, we have also been wanting to sign the jars (Same way as Minecraft) this PR does both. This has is being done on a remote server to ensure the security of these keys.


For projects that aren't going onto maven central I wish to also sign those even though its not a requirement.