### PR TITLE
Add strict record checking.

### DIFF
--- a/src/main/java/net/fabricmc/accesswidener/AccessWidener.java
+++ b/src/main/java/net/fabricmc/accesswidener/AccessWidener.java
@@ -207,6 +207,14 @@ public final class AccessWidener implements AccessWidenerVisitor {
 		public int apply(int access, String targetName, int ownerAccess) {
 			return operator.apply(access, targetName, ownerAccess);
 		}
+
+		public static boolean isAccessible(Access access) {
+			return access == ACCESSIBLE || access == ACCESSIBLE_EXTENDABLE;
+		}
+
+		public static boolean isExtendable(Access access) {
+			return access == EXTENDABLE || access == ACCESSIBLE_EXTENDABLE;
+		}
 	}
 
 	enum MethodAccess implements Access {
@@ -247,6 +255,14 @@ public final class AccessWidener implements AccessWidenerVisitor {
 		@Override
 		public int apply(int access, String targetName, int ownerAccess) {
 			return operator.apply(access, targetName, ownerAccess);
+		}
+
+		public static boolean isAccessible(Access access) {
+			return access == ACCESSIBLE || access == ACCESSIBLE_EXTENDABLE;
+		}
+
+		public static boolean isExtendable(Access access) {
+			return access == EXTENDABLE || access == ACCESSIBLE_EXTENDABLE;
 		}
 	}
 
@@ -302,6 +318,14 @@ public final class AccessWidener implements AccessWidenerVisitor {
 		@Override
 		public int apply(int access, String targetName, int ownerAccess) {
 			return operator.apply(access, targetName, ownerAccess);
+		}
+
+		public static boolean isAccessible(Access access) {
+			return access == ACCESSIBLE || access == ACCESSIBLE_MUTABLE;
+		}
+
+		public static boolean isMutable(Access access) {
+			return access == MUTABLE || access == ACCESSIBLE_MUTABLE;
 		}
 	}
 

--- a/src/test/java/test/PrivateInnerRecord.java
+++ b/src/test/java/test/PrivateInnerRecord.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test;
+
+public class PrivateInnerRecord {
+	private static record Inner(int i) {
+	}
+}


### PR DESCRIPTION
Record classes cannot be made extendable.
Record fields that match a component cannot be made mutable.

I added this an option (on by default) to allow disabling this check incase the record components do not match the field names + desc.