### PR TITLE
Fix #14

### DIFF
--- a/src/test/java/net/fabricmc/accesswidener/AccessWidenerClassVisitorTest.java
+++ b/src/test/java/net/fabricmc/accesswidener/AccessWidenerClassVisitorTest.java
@@ -200,9 +200,11 @@ class AccessWidenerClassVisitorTest {
 			widener.getTargets().add("test.PrivateMethodSubclassTest$Subclass");
 			Class<?> testClass = applyTransformer().get("test.PrivateMethodSubclassTest");
 			int result = (int) testClass.getMethod("callMethodOnSubclass").invoke(null);
+			int resultWithLambda = (int) testClass.getMethod("callMethodWithLambdaOnSubclass").invoke(null);
 			// this signifies that the INVOKESPECIAL instruction got rewritten to INVOKEVIRTUAL and the
 			// method of the same name in the subclass was invoked.
 			assertThat(result).isEqualTo(456);
+			assertThat(resultWithLambda).isEqualTo(456);
 		}
 	}
 

--- a/src/test/java/test/PrivateMethodSubclassTest.java
+++ b/src/test/java/test/PrivateMethodSubclassTest.java
@@ -16,6 +16,8 @@
 
 package test;
 
+import java.util.function.Supplier;
+
 public class PrivateMethodSubclassTest {
 	private int test() {
 		return 123;
@@ -26,11 +28,22 @@ public class PrivateMethodSubclassTest {
 		return test();
 	}
 
+	private int callPrivateMethodWithLambda() {
+		// Private method handles tag in bootstrap method arguments should be H_INVOKESPECIAL
+		Supplier<Integer> supplier = this::test;
+		return supplier.get();
+	}
+
 	public static int callMethodOnSubclass() {
 		// Without making test() extendable or accessible, this will call the private method, even on the subclass
 		// otherwise it'll call the subclasses method. This is detectable from the return value.
 		PrivateMethodSubclassTest r = new Subclass();
 		return r.callPrivateMethod();
+	}
+
+	public static int callMethodWithLambdaOnSubclass() {
+		PrivateMethodSubclassTest r = new Subclass();
+		return r.callPrivateMethodWithLambda();
 	}
 
 	public static class Subclass extends PrivateMethodSubclassTest {


### PR DESCRIPTION
some wonderful features about https://github.com/FabricMC/access-widener/issues/14
1. compile the test case with java 8 (because after java 11 (jep 181), compiler will generate `invokevirtual` instead of `invokespecial` where the private method is called)
2. modify testPrivate to public in bytecode
3. running with java before 14 and after 15 will get different results

https://openjdk.java.net/jeps/371
```
To invoke private nestmate instance methods from code in a hidden class, use invokevirtual or invokeinterface instead 
of invokespecial. Generated bytecode that uses invokespecial to invoke a private nestmate instance method will fail 
verification. invokespecial should only be used to invoke private nestmate constructors.
```
`h_invokespecial` would be replaced by `h_invokevirtual` at runtime after java 15