### PR TITLE
Added compound access widdener declerations.

### DIFF
--- a/src/main/java/net/fabricmc/accesswidener/AccessWidenerRemapper.java
+++ b/src/main/java/net/fabricmc/accesswidener/AccessWidenerRemapper.java
@@ -18,6 +18,8 @@ package net.fabricmc.accesswidener;
 
 import org.objectweb.asm.commons.Remapper;
 
+import java.util.Set;
+
 /**
  * Decorates a {@link AccessWidenerVisitor} with a {@link Remapper}
  * to remap names passing through the visitor if they come from a different namespace.
@@ -58,12 +60,12 @@ public final class AccessWidenerRemapper implements AccessWidenerVisitor {
 	}
 
 	@Override
-	public void visitClass(String name, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitClass(String name, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		delegate.visitClass(remapper.map(name), access, transitive);
 	}
 
 	@Override
-	public void visitMethod(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitMethod(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		delegate.visitMethod(
 				remapper.map(owner),
 				remapper.mapMethodName(owner, name, descriptor),
@@ -74,7 +76,7 @@ public final class AccessWidenerRemapper implements AccessWidenerVisitor {
 	}
 
 	@Override
-	public void visitField(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitField(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		delegate.visitField(
 				remapper.map(owner),
 				remapper.mapFieldName(owner, name, descriptor),

--- a/src/main/java/net/fabricmc/accesswidener/AccessWidenerVisitor.java
+++ b/src/main/java/net/fabricmc/accesswidener/AccessWidenerVisitor.java
@@ -16,6 +16,9 @@
 
 package net.fabricmc.accesswidener;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * A visitor of the entries defined in an access widener file.
  */
@@ -35,7 +38,18 @@ public interface AccessWidenerVisitor {
 	 * @param access     the access type ({@link AccessWidenerReader.AccessType#ACCESSIBLE} or {@link AccessWidenerReader.AccessType#EXTENDABLE})
 	 * @param transitive whether this widener should be applied across mod boundaries
 	 */
+	default void visitClass(String name, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
+	}
+	
+	/**
+	 * Visits a widened class.
+	 *
+	 * @param name       the name of the class
+	 * @param access     the access type ({@link AccessWidenerReader.AccessType#ACCESSIBLE} or {@link AccessWidenerReader.AccessType#EXTENDABLE})
+	 * @param transitive whether this widener should be applied across mod boundaries
+	 */
 	default void visitClass(String name, AccessWidenerReader.AccessType access, boolean transitive) {
+		visitClass(name, Collections.singleton(access), transitive);
 	}
 
 	/**
@@ -47,7 +61,20 @@ public interface AccessWidenerVisitor {
 	 * @param access     the access type ({@link AccessWidenerReader.AccessType#ACCESSIBLE} or {@link AccessWidenerReader.AccessType#EXTENDABLE})
 	 * @param transitive whether this widener should be applied across mod boundaries
 	 */
+	default void visitMethod(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
+	}
+	
+	/**
+	 * Visits a widened method.
+	 *
+	 * @param owner      the name of the containing class
+	 * @param name       the name of the method
+	 * @param descriptor the method descriptor
+	 * @param access     the access type ({@link AccessWidenerReader.AccessType#ACCESSIBLE} or {@link AccessWidenerReader.AccessType#EXTENDABLE})
+	 * @param transitive whether this widener should be applied across mod boundaries
+	 */
 	default void visitMethod(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+		visitMethod(owner, name, descriptor, Collections.singleton(access), transitive);
 	}
 
 	/**
@@ -59,6 +86,19 @@ public interface AccessWidenerVisitor {
 	 * @param access     the access type ({@link AccessWidenerReader.AccessType#ACCESSIBLE} or {@link AccessWidenerReader.AccessType#MUTABLE})
 	 * @param transitive whether this widener should be applied across mod boundaries
 	 */
+	default void visitField(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
+	}
+	
+	/**
+	 * Visits a widened field.
+	 *
+	 * @param owner      the name of the containing class
+	 * @param name       the name of the field
+	 * @param descriptor the type of the field as a type descriptor
+	 * @param access     the access type ({@link AccessWidenerReader.AccessType#ACCESSIBLE} or {@link AccessWidenerReader.AccessType#MUTABLE})
+	 * @param transitive whether this widener should be applied across mod boundaries
+	 */
 	default void visitField(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+		visitField(owner, name, descriptor, Collections.singleton(access), transitive);
 	}
 }

--- a/src/main/java/net/fabricmc/accesswidener/AccessWidenerWriter.java
+++ b/src/main/java/net/fabricmc/accesswidener/AccessWidenerWriter.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.accesswidener;
 
+import java.util.Set;
+
 public final class AccessWidenerWriter implements AccessWidenerVisitor {
 	private final StringBuilder builder = new StringBuilder();
 	private final int version;
@@ -53,20 +55,20 @@ public final class AccessWidenerWriter implements AccessWidenerVisitor {
 	}
 
 	@Override
-	public void visitClass(String name, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitClass(String name, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		writeAccess(access, transitive);
 		builder.append("\tclass\t").append(name).append('\n');
 	}
 
 	@Override
-	public void visitMethod(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitMethod(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		writeAccess(access, transitive);
 		builder.append("\tmethod\t").append(owner).append('\t').append(name)
 				.append('\t').append(descriptor).append('\n');
 	}
 
 	@Override
-	public void visitField(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitField(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		writeAccess(access, transitive);
 		builder.append("\tfield\t").append(owner).append('\t').append(name)
 				.append('\t').append(descriptor).append('\n');
@@ -84,7 +86,7 @@ public final class AccessWidenerWriter implements AccessWidenerVisitor {
 		return builder.toString();
 	}
 
-	private void writeAccess(AccessWidenerReader.AccessType access, boolean transitive) {
+	private void writeAccess(Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		if (transitive) {
 			if (version < 2) {
 				throw new IllegalStateException("Cannot write transitive rule in version " + version);

--- a/src/main/java/net/fabricmc/accesswidener/ForwardingVisitor.java
+++ b/src/main/java/net/fabricmc/accesswidener/ForwardingVisitor.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.accesswidener;
 
+import java.util.Set;
+
 /**
  * Forwards visitor events to multiple other visitors.
  */
@@ -34,21 +36,21 @@ public class ForwardingVisitor implements AccessWidenerVisitor {
 	}
 
 	@Override
-	public void visitClass(String name, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitClass(String name, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		for (AccessWidenerVisitor visitor : visitors) {
 			visitor.visitClass(name, access, transitive);
 		}
 	}
 
 	@Override
-	public void visitMethod(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitMethod(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		for (AccessWidenerVisitor visitor : visitors) {
 			visitor.visitMethod(owner, name, descriptor, access, transitive);
 		}
 	}
 
 	@Override
-	public void visitField(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitField(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		for (AccessWidenerVisitor visitor : visitors) {
 			visitor.visitField(owner, name, descriptor, access, transitive);
 		}

--- a/src/main/java/net/fabricmc/accesswidener/TransitiveOnlyFilter.java
+++ b/src/main/java/net/fabricmc/accesswidener/TransitiveOnlyFilter.java
@@ -16,6 +16,8 @@
 
 package net.fabricmc.accesswidener;
 
+import java.util.Set;
+
 /**
  * Decorates a visitor to only receive elements that are marked as transitive.
  */
@@ -32,21 +34,21 @@ public final class TransitiveOnlyFilter implements AccessWidenerVisitor {
 	}
 
 	@Override
-	public void visitClass(String name, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitClass(String name, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		if (transitive) {
 			delegate.visitClass(name, access, transitive);
 		}
 	}
 
 	@Override
-	public void visitMethod(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitMethod(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		if (transitive) {
 			delegate.visitMethod(owner, name, descriptor, access, transitive);
 		}
 	}
 
 	@Override
-	public void visitField(String owner, String name, String descriptor, AccessWidenerReader.AccessType access, boolean transitive) {
+	public void visitField(String owner, String name, String descriptor, Set<AccessWidenerReader.AccessType> access, boolean transitive) {
 		if (transitive) {
 			delegate.visitField(owner, name, descriptor, access, transitive);
 		}


### PR DESCRIPTION
This enables members that require multiple mutations for desired usage to be acted upon.

For example if you have the class
```Java
package test;

public final class Test {
    private final String superSecret = "Mojang";
}
```
you can't make `superSecret` accessible and mutable, you can only change it to `public final` or `private` but not `public`.

With this change set you can use
```Accesswidener
accesswidener	v1	named

accessible|mutable	field	test/Test	superSecret	Ljava/lang/String;
```
to mutate `test.Test` to resemble the following
```Java
package test;

public final class Test {
    public String superSecret = "Mojang";
}
```

I know that in the context of Fabric mods this is not the preferred way of doing this, but this may be useful in other contexts.